### PR TITLE
Fix output data corruption on Windows

### DIFF
--- a/source/io/output_stream.h
+++ b/source/io/output_stream.h
@@ -7,6 +7,10 @@
 #include <algorithm>
 #include <array>
 #include <assert.h>
+#ifdef _WIN32
+	#include <fcntl.h>
+	#include <io.h>
+#endif
 
 /**
  * \brief Thread-safe binary output stream.
@@ -31,6 +35,10 @@ public:
 		if (filename == "stdout")
 		{
 			file = &std::cout;
+			// By default stdout is in text mode on Windows
+			#ifdef _WIN32
+				_setmode(_fileno(stdout), _O_BINARY);
+			#endif
 			own_file = false;
 		}
 		else


### PR DESCRIPTION
Turns out, on Windows `stdout` by default is opened in text mode, which makes compiler (at least MSVC) add a carriage return code (0D) before each line feed code (0A), corrupting binary output data. This fix adjusts the mode to binary when compiling on Windows.

*P.S.* Amazing work you guys have done on this project! The performance difference in comparison to e.g. Casino is just astonishing.